### PR TITLE
remove extension to bsd from about page

### DIFF
--- a/pages/about.md
+++ b/pages/about.md
@@ -8,7 +8,7 @@ layout: default
 
 Development and promotion of the Functional Mock-up Interface (FMI) standard. The intention is to simplify the creation, storage, exchange and (re-) use of dynamic system models of different simluation systems for model/software/hardware-in-the-loop simulation, for cyber physical systems, and other applications.
 
-The FMI specifications are published under the CC-BY-SA (Creative Common Attribution-ShareAlike 4.0 International) license, i.e., the license used by Wikipedia. A human-readable summary of the license text is available from [http://creativecommons.org/licenses/by-sa/4.0](https://creativecommons.org/licenses/by-sa/4.0). Source code, such as C-header and XML-schema files, that accompany the specification documents are provided under the [BSD license](https://www.opensource.org/licenses/bsd-license.html) with the extension that modifications must be also provided under the BSD license.
+The FMI specifications are published under the CC-BY-SA (Creative Common Attribution-ShareAlike 4.0 International) license, i.e., the license used by Wikipedia. A human-readable summary of the license text is available from [http://creativecommons.org/licenses/by-sa/4.0](https://creativecommons.org/licenses/by-sa/4.0). Source code, such as C-header and XML-schema files, that accompany the specification documents are provided under the [BSD license](https://www.opensource.org/licenses/bsd-license.html).
 
 FMI is a registered trademark. The rules for trademark usage are [here](https://svn.fmi-standard.org/fmi/branches/public/docs/Trademark%20Guidelines%20for%20the%20Use%20of%20the%20FMI%20Trademark%20V1.0.pdf).
 


### PR DESCRIPTION
as in FMI 2.0.1 this extension is no longer there.